### PR TITLE
Null pointer after tried connect again from bluetooth audio device

### DIFF
--- a/src/com/android/bluetooth/a2dp/A2dpCodecConfig.java
+++ b/src/com/android/bluetooth/a2dp/A2dpCodecConfig.java
@@ -110,7 +110,7 @@ class A2dpCodecConfig {
         // Set the mandatory codec's priority to default, and remove the rest
         for (int i = 0; i < assigned_codec_length; i++) {
             BluetoothCodecConfig codecConfig = codecConfigArray[i];
-            if (!codecConfig.isMandatoryCodec()) {
+            if (codecConfig != null && !codecConfig.isMandatoryCodec()) {
                 codecConfigArray[i] = null;
             }
         }
@@ -131,7 +131,7 @@ class A2dpCodecConfig {
         // Set the mandatory codec's priority to highest, and remove the rest
         for (int i = 0; i < assigned_codec_length; i++) {
             BluetoothCodecConfig codecConfig = codecConfigArray[i];
-            if (codecConfig.isMandatoryCodec()) {
+            if (codecConfig != null && codecConfig.isMandatoryCodec()) {
                 codecConfig.setCodecPriority(BluetoothCodecConfig.CODEC_PRIORITY_HIGHEST);
             } else {
                 codecConfigArray[i] = null;


### PR DESCRIPTION
One user reported, it cherry-picked from crDroid 6 (10.0) source.

01-21 16:22:45.225 E/AndroidRuntime(20850): FATAL EXCEPTION: A2dpService.StateMachines
01-21 16:22:45.225 E/AndroidRuntime(20850): Process: com.android.bluetooth, PID: 20850
01-21 16:22:45.225 E/AndroidRuntime(20850): java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.bluetooth.BluetoothCodecConfig.isMandatoryCodec()' on a null object reference
01-21 16:22:45.225 E/AndroidRuntime(20850): 	at com.android.bluetooth.a2dp.A2dpCodecConfig.disableOptionalCodecs(A2dpCodecConfig.java:152)
01-21 16:22:45.225 E/AndroidRuntime(20850): 	at com.android.bluetooth.a2dp.A2dpService.disableOptionalCodecs(A2dpService.java:812)
01-21 16:22:45.225 E/AndroidRuntime(20850): 	at com.android.bluetooth.a2dp.A2dpService.updateOptionalCodecsSupport(A2dpService.java:1122)
01-21 16:22:45.225 E/AndroidRuntime(20850): 	at com.android.bluetooth.a2dp.A2dpStateMachine$Connected.enter(A2dpStateMachine.java:475)
01-21 16:22:45.225 E/AndroidRuntime(20850): 	at com.android.bluetooth.statemachine.StateMachine$SmHandler.invokeEnterMethods(StateMachine.java:1036)
01-21 16:22:45.225 E/AndroidRuntime(20850): 	at com.android.bluetooth.statemachine.StateMachine$SmHandler.performTransitions(StateMachine.java:878)
01-21 16:22:45.225 E/AndroidRuntime(20850): 	at com.android.bluetooth.statemachine.StateMachine$SmHandler.handleMessage(StateMachine.java:818)
01-21 16:22:45.225 E/AndroidRuntime(20850): 	at android.os.Handler.dispatchMessage(Handler.java:106)
01-21 16:22:45.225 E/AndroidRuntime(20850): 	at android.os.Looper.loop(Looper.java:223)
01-21 16:22:45.225 E/AndroidRuntime(20850): 	at android.os.HandlerThread.run(HandlerThread.java:67)